### PR TITLE
Prometheus Remote Write Exporter (2/7)

### DIFF
--- a/exporter/opentelemetry-exporter-prometheus-remote-write/src/opentelemetry/exporter/prometheus_remote_write/__init__.py
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/src/opentelemetry/exporter/prometheus_remote_write/__init__.py
@@ -46,7 +46,79 @@ class PrometheusRemoteWriteMetricsExporter(MetricsExporter):
         bearer_token_file: str = None,
         headers: Dict = None,
     ):
-        raise NotImplementedError()
+        self.endpoint = endpoint
+        if basic_auth:
+            self.basic_auth = basic_auth
+        if bearer_token:
+            self.bearer_token = bearer_token
+        if bearer_token_file:
+            self.bearer_token_file = bearer_token_file
+        if headers:
+            self.headers = headers
+
+    @property
+    def endpoint(self):
+        return self._endpoint
+
+    @endpoint.setter
+    def endpoint(self, endpoint: str):
+        if endpoint == "":
+            raise ValueError("endpoint required")
+        self._endpoint = endpoint
+
+    @property
+    def basic_auth(self):
+        return self._basic_auth
+
+    @basic_auth.setter
+    def basic_auth(self, basic_auth: Dict):
+        if hasattr(self, "bearer_token") or hasattr(self, "bearer_token_file"):
+            raise ValueError("cannot contain basic_auth and bearer_token")
+        if "username" not in basic_auth:
+            raise ValueError("username required in basic_auth")
+        if "password" not in basic_auth and "password_file" not in basic_auth:
+            raise ValueError("password required in basic_auth")
+        if "password" in basic_auth and "password_file" in basic_auth:
+            raise ValueError(
+                "basic_auth cannot contain password and password_file"
+            )
+        self._basic_auth = basic_auth
+
+    @property
+    def bearer_token(self):
+        return self._bearer_token
+
+    @bearer_token.setter
+    def bearer_token(self, bearer_token: str):
+        if hasattr(self, "basic_auth"):
+            raise ValueError("cannot contain basic_auth and bearer_token")
+        if hasattr(self, "bearer_token_file"):
+            raise ValueError(
+                "cannot contain bearer_token and bearer_token_file"
+            )
+        self._bearer_token = bearer_token
+
+    @property
+    def bearer_token_file(self):
+        return self._bearer_token_file
+
+    @bearer_token_file.setter
+    def bearer_token_file(self, bearer_token_file: str):
+        if hasattr(self, "basic_auth"):
+            raise ValueError("cannot contain basic_auth and bearer_token")
+        if hasattr(self, "bearer_token"):
+            raise ValueError(
+                "cannot contain bearer_token and bearer_token_file"
+            )
+        self._bearer_token_file = bearer_token_file
+
+    @property
+    def headers(self):
+        return self._headers
+
+    @headers.setter
+    def headers(self, headers: Dict):
+        self._headers = headers
 
     def export(
         self, export_records: Sequence[ExportRecord]

--- a/exporter/opentelemetry-exporter-prometheus-remote-write/tests/test_prometheus_remote_write_exporter.py
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/tests/test_prometheus_remote_write_exporter.py
@@ -14,35 +14,77 @@
 
 import unittest
 
+from opentelemetry.exporter.prometheus_remote_write import (
+    PrometheusRemoteWriteMetricsExporter,
+)
+
 
 class TestValidation(unittest.TestCase):
     # Test cases to ensure exporter parameter validation works as intended
     def test_valid_standard_param(self):
-        pass
+        PrometheusRemoteWriteMetricsExporter(endpoint="/prom/test_endpoint")
 
     def test_valid_basic_auth_param(self):
-        pass
+        PrometheusRemoteWriteMetricsExporter(
+            endpoint="/prom/test_endpoint",
+            basic_auth={
+                "username": "test_username",
+                "password": "test_password",
+            },
+        )
 
     def test_valid_bearer_token_param(self):
-        pass
+        PrometheusRemoteWriteMetricsExporter(
+            endpoint="/prom/test_endpoint", bearer_token="test_bearer_token",
+        )
 
     def test_invalid_no_endpoint_param(self):
-        pass
+        with self.assertRaises(ValueError):
+            PrometheusRemoteWriteMetricsExporter("")
 
     def test_invalid_no_username_param(self):
-        pass
+        with self.assertRaises(ValueError):
+            PrometheusRemoteWriteMetricsExporter(
+                endpoint="/prom/test_endpoint",
+                basic_auth={"password": "test_password"},
+            )
 
     def test_invalid_no_password_param(self):
-        pass
+        with self.assertRaises(ValueError):
+            PrometheusRemoteWriteMetricsExporter(
+                endpoint="/prom/test_endpoint",
+                basic_auth={"username": "test_username"},
+            )
 
     def test_invalid_conflicting_passwords_param(self):
-        pass
+        with self.assertRaises(ValueError):
+            PrometheusRemoteWriteMetricsExporter(
+                endpoint="/prom/test_endpoint",
+                basic_auth={
+                    "username": "test_username",
+                    "password": "test_password",
+                    "password_file": "test_file",
+                },
+            )
 
     def test_invalid_conflicting_bearer_tokens_param(self):
-        pass
+        with self.assertRaises(ValueError):
+            PrometheusRemoteWriteMetricsExporter(
+                endpoint="/prom/test_endpoint",
+                bearer_token="test_bearer_token",
+                bearer_token_file="test_file",
+            )
 
     def test_invalid_conflicting_auth_param(self):
-        pass
+        with self.assertRaises(ValueError):
+            PrometheusRemoteWriteMetricsExporter(
+                endpoint="/prom/test_endpoint",
+                basic_auth={
+                    "username": "test_username",
+                    "password": "test_password",
+                },
+                bearer_token="test_bearer_token",
+            )
 
 
 class TestConversion(unittest.TestCase):


### PR DESCRIPTION
# Description
This is PR 2/7 of adding a Prometheus Remote Write Exporter in Python SDK and address Issue https://github.com/open-telemetry/opentelemetry-python/issues/1302

**[Part 1/7](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/180)**
* Adds class skeleton
* Adds all function signatures


👉 **[Part 2/7](https://github.com/open-o11y/opentelemetry-python-contrib/pull/9)**
* Adds validation of exporter constructor commands
* Add unit tests for validation

**[Part 3/7](https://github.com/open-o11y/opentelemetry-python-contrib/pull/11)**
* Adds conversion methods from OTel metric types to Prometheus [TimeSeries](https://github.com/prometheus/prometheus/blob/master/prompb/types.proto#L47)
* Add unit tests for conversion


**[Part 4/7](https://github.com/open-o11y/opentelemetry-python-contrib/pull/12)**
* Adds methods to export metrics to Remote Write endpoint
* Add unit tests for exporting

**Part 5/7**
* Add support for optional request parameters (timeout, proxy)
* Add support for tls config

**Part 6/7**
* Add integration tests using sample app and instance of Cortex

**Part 7/7**
* Add README, Design Doc and other necessary documentation.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
# How Has This Been Tested?

- [ ] Added class `TestValidation` in `test_prometheus_remote_write_exporter.py`

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:
- [x] Followed the style guidelines of this project
- [ ] ~~Changelogs have been updated~~ (change logs will be updated when PR 7/7 is merged and the RW exporter is complete)
- [x] Unit tests have been added
- [ ] ~~Documentation has been updated~~
cc- @shovnik, @alolita 