### PR TITLE
Prometheus Remote Write Exporter (3/7)

### DIFF
--- a/exporter/opentelemetry-exporter-prometheus-remote-write/tests/test_prometheus_remote_write_exporter.py
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/tests/test_prometheus_remote_write_exporter.py
@@ -13,10 +13,25 @@
 # limitations under the License.
 
 import unittest
+from unittest import mock
 
 from opentelemetry.exporter.prometheus_remote_write import (
     PrometheusRemoteWriteMetricsExporter,
 )
+from opentelemetry.exporter.prometheus_remote_write.gen.types_pb2 import (
+    TimeSeries,
+)
+from opentelemetry.sdk.metrics import Counter
+from opentelemetry.sdk.metrics.export import ExportRecord, MetricsExportResult
+from opentelemetry.sdk.metrics.export.aggregate import (
+    HistogramAggregator,
+    LastValueAggregator,
+    MinMaxSumCountAggregator,
+    SumAggregator,
+    ValueObserverAggregator,
+)
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.util import get_dict_as_key
 
 
 class TestValidation(unittest.TestCase):
@@ -90,35 +105,151 @@ class TestValidation(unittest.TestCase):
 class TestConversion(unittest.TestCase):
     # Initializes test data that is reused across tests
     def setUp(self):
-        pass
+        self._test_metric = Counter(
+            "testname", "testdesc", "testunit", int, None
+        )
+        self._exporter = PrometheusRemoteWriteMetricsExporter(
+            endpoint="/prom/test_endpoint"
+        )
+
+        def generate_record(aggregator_type):
+            return ExportRecord(
+                self._test_metric, None, aggregator_type(), Resource({}),
+            )
+
+        self._generate_record = generate_record
+
+        def converter_method(record, name, value):
+            return (type(record.aggregator), name, value)
+
+        self._converter_mock = mock.MagicMock(return_value=converter_method)
 
     # Ensures conversion to timeseries function works with valid aggregation types
     def test_valid_convert_to_timeseries(self):
-        pass
+        timeseries_mock_method = mock.Mock(return_value=["test_value"])
+        self._exporter.convert_from_sum = timeseries_mock_method
+        self._exporter.convert_from_min_max_sum_count = timeseries_mock_method
+        self._exporter.convert_from_histogram = timeseries_mock_method
+        self._exporter.convert_from_last_value = timeseries_mock_method
+        self._exporter.convert_from_value_observer = timeseries_mock_method
+        test_records = [
+            self._generate_record(SumAggregator),
+            self._generate_record(MinMaxSumCountAggregator),
+            self._generate_record(HistogramAggregator),
+            self._generate_record(LastValueAggregator),
+            self._generate_record(ValueObserverAggregator),
+        ]
+        data = self._exporter.convert_to_timeseries(test_records)
+        self.assertEqual(len(data), 5)
+        for timeseries in data:
+            self.assertEqual(timeseries, "test_value")
+
+        no_type_records = [self._generate_record(lambda: None)]
+        with self.assertRaises(ValueError):
+            self._exporter.convert_to_timeseries(no_type_records)
 
     # Ensures conversion to timeseries fails for unsupported aggregation types
     def test_invalid_convert_to_timeseries(self):
-        pass
+        no_type_records = [self._generate_record(lambda: None)]
+        with self.assertRaises(ValueError):
+            self._exporter.convert_to_timeseries(no_type_records)
 
     # Ensures sum aggregator is correctly converted to timeseries
     def test_convert_from_sum(self):
-        pass
+        sum_record = self._generate_record(SumAggregator)
+        sum_record.aggregator.update(3)
+        sum_record.aggregator.update(2)
+        sum_record.aggregator.take_checkpoint()
+
+        self._exporter.create_timeseries = self._converter_mock()
+        timeseries = self._exporter.convert_from_sum(sum_record)
+        self.assertEqual(timeseries[0], (SumAggregator, "testname", 5))
 
     # Ensures sum min_max_count aggregator is correctly converted to timeseries
     def test_convert_from_min_max_sum_count(self):
-        pass
+        min_max_sum_count_record = self._generate_record(
+            MinMaxSumCountAggregator
+        )
+        min_max_sum_count_record.aggregator.update(5)
+        min_max_sum_count_record.aggregator.update(1)
+        min_max_sum_count_record.aggregator.take_checkpoint()
+
+        self._exporter.create_timeseries = self._converter_mock()
+        timeseries = self._exporter.convert_from_min_max_sum_count(
+            min_max_sum_count_record
+        )
+        self.assertEqual(
+            timeseries[0], (MinMaxSumCountAggregator, "testname_min", 1)
+        )
+        self.assertEqual(
+            timeseries[1], (MinMaxSumCountAggregator, "testname_max", 5)
+        )
+        self.assertEqual(
+            timeseries[2], (MinMaxSumCountAggregator, "testname_sum", 6)
+        )
+        self.assertEqual(
+            timeseries[3], (MinMaxSumCountAggregator, "testname_count", 2)
+        )
 
     # Ensures histogram aggregator is correctly converted to timeseries
     def test_convert_from_histogram(self):
-        pass
+        histogram_record = self._generate_record(HistogramAggregator)
+        histogram_record.aggregator.update(5)
+        histogram_record.aggregator.update(2)
+        histogram_record.aggregator.update(-1)
+        histogram_record.aggregator.take_checkpoint()
+
+        self._exporter.create_timeseries = self._converter_mock()
+        timeseries = self._exporter.convert_from_histogram(histogram_record)
+        self.assertEqual(
+            timeseries[0], (HistogramAggregator, 'testname_bucket{le="0"}', 1)
+        )
+        self.assertEqual(
+            timeseries[1],
+            (HistogramAggregator, 'testname_bucket{le="+Inf"}', 2),
+        )
+        self.assertEqual(
+            timeseries[2], (HistogramAggregator, "testname_count", 3)
+        )
 
     # Ensures last value aggregator is correctly converted to timeseries
     def test_convert_from_last_value(self):
-        pass
+        last_value_record = self._generate_record(LastValueAggregator)
+        last_value_record.aggregator.update(1)
+        last_value_record.aggregator.update(5)
+        last_value_record.aggregator.take_checkpoint()
+
+        self._exporter.create_timeseries = self._converter_mock()
+        timeseries = self._exporter.convert_from_last_value(last_value_record)
+        self.assertEqual(timeseries[0], (LastValueAggregator, "testname", 5))
 
     # Ensures value observer aggregator is correctly converted to timeseries
     def test_convert_from_value_observer(self):
-        pass
+        value_observer_record = self._generate_record(ValueObserverAggregator)
+        value_observer_record.aggregator.update(5)
+        value_observer_record.aggregator.update(1)
+        value_observer_record.aggregator.update(2)
+        value_observer_record.aggregator.take_checkpoint()
+
+        self._exporter.create_timeseries = self._converter_mock()
+        timeseries = self._exporter.convert_from_value_observer(
+            value_observer_record
+        )
+        self.assertEqual(
+            timeseries[0], (ValueObserverAggregator, "testname_min", 1)
+        )
+        self.assertEqual(
+            timeseries[1], (ValueObserverAggregator, "testname_max", 5)
+        )
+        self.assertEqual(
+            timeseries[2], (ValueObserverAggregator, "testname_sum", 8)
+        )
+        self.assertEqual(
+            timeseries[3], (ValueObserverAggregator, "testname_count", 3)
+        )
+        self.assertEqual(
+            timeseries[4], (ValueObserverAggregator, "testname_last", 2)
+        )
 
     # Ensures quantile aggregator is correctly converted to timeseries
     # TODO: Add test once method is implemented
@@ -127,7 +258,34 @@ class TestConversion(unittest.TestCase):
 
     # Ensures timeseries produced contains appropriate sample and labels
     def test_create_timeseries(self):
-        pass
+        sum_aggregator = SumAggregator()
+        sum_aggregator.update(5)
+        sum_aggregator.take_checkpoint()
+        sum_aggregator.last_update_timestamp = 10
+        export_record = ExportRecord(
+            self._test_metric,
+            get_dict_as_key({"record_name": "record_value"}),
+            sum_aggregator,
+            Resource({"resource_name": "resource_value"}),
+        )
+
+        expected_timeseries = TimeSeries()
+        expected_timeseries.labels.append(
+            self._exporter.create_label("__name__", "testname")
+        )
+        expected_timeseries.labels.append(
+            self._exporter.create_label("resource_name", "resource_value")
+        )
+        expected_timeseries.labels.append(
+            self._exporter.create_label("record_name", "record_value")
+        )
+        expected_timeseries.samples.append(
+            self._exporter.create_sample(10, 5.0),
+        )
+        timeseries = self._exporter.create_timeseries(
+            export_record, "testname", 5.0,
+        )
+        self.assertEqual(timeseries, expected_timeseries)
 
 
 class TestExport(unittest.TestCase):


### PR DESCRIPTION
# Description
This is PR 3/7 of adding a Prometheus Remote Write Exporter in Python SDK and address Issue https://github.com/open-telemetry/opentelemetry-python/issues/1302

**[Part 1/7](https://github.com/open-o11y/opentelemetry-python-contrib/pull/10)**
* Adds class skeleton
* Adds all function signatures


**[Part 2/7](https://github.com/open-o11y/opentelemetry-python-contrib/pull/9)**
* Adds validation of exporter constructor commands
* Add unit tests for validation

👉 **[Part 3/7](https://github.com/open-o11y/opentelemetry-python-contrib/pull/11)**
* Adds conversion methods from OTel metric types to Prometheus [TimeSeries](https://github.com/prometheus/prometheus/blob/master/prompb/types.proto#L47)
* Add unit tests for conversion


**[Part 4/7](https://github.com/open-o11y/opentelemetry-python-contrib/pull/12)**
* Adds methods to export metrics to Remote Write endpoint
* Add unit tests for exporting

**Part 5/7**
* Add support for optional request parameters (timeout, proxy)
* Add support for tls config

**Part 6/7**
* Add integration tests using sample app and instance of Cortex

**Part 7/7**
* Add README, Design Doc and other necessary documentation.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
# How Has This Been Tested?

- [ ] Added class `TestValidation` in `test_prometheus_remote_write_exporter.py`

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:
- [x] Followed the style guidelines of this project
- [ ] ~~Changelogs have been updated~~ (change logs will be updated when PR 7/7 is merged and the RW exporter is complete)
- [x] Unit tests have been added
- [ ] ~~Documentation has been updated~~
cc- @AzfaarQureshi , @alolita 