### PR TITLE
Prometheus Remote Write Exporter (4/7)

### DIFF
--- a/exporter/opentelemetry-exporter-prometheus-remote-write/CHANGELOG.md
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/CHANGELOG.md
@@ -9,3 +9,5 @@
   ((#206)[https://github.com/open-telemetry/opentelemetry-python-contrib/pull/206])
 - Add conversion to TimeSeries methods
   ((#207)[https://github.com/open-telemetry/opentelemetry-python-contrib/pull/207])
+- Add request methods
+  ((#212)[https://github.com/open-telemetry/opentelemetry-python-contrib/pull/212])

--- a/exporter/opentelemetry-exporter-prometheus-remote-write/src/opentelemetry/exporter/prometheus_remote_write/__init__.py
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/src/opentelemetry/exporter/prometheus_remote_write/__init__.py
@@ -12,9 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import re
 from typing import Dict, Sequence
 
+import requests
+
+import snappy
 from opentelemetry.exporter.prometheus_remote_write.gen.remote_pb2 import (
     WriteRequest,
 )
@@ -35,6 +39,8 @@ from opentelemetry.sdk.metrics.export.aggregate import (
     SumAggregator,
     ValueObserverAggregator,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class PrometheusRemoteWriteMetricsExporter(MetricsExporter):
@@ -148,10 +154,13 @@ class PrometheusRemoteWriteMetricsExporter(MetricsExporter):
     def export(
         self, export_records: Sequence[ExportRecord]
     ) -> MetricsExportResult:
-        raise NotImplementedError()
+        timeseries = self.convert_to_timeseries(export_records)
+        message = self.build_message(timeseries)
+        headers = self.get_headers()
+        return self.send_message(message, headers)
 
     def shutdown(self) -> None:
-        raise NotImplementedError()
+        pass
 
     def convert_to_timeseries(
         self, export_records: Sequence[ExportRecord]
@@ -280,12 +289,66 @@ class PrometheusRemoteWriteMetricsExporter(MetricsExporter):
         return label
 
     def build_message(self, timeseries: Sequence[TimeSeries]) -> bytes:
-        raise NotImplementedError()
+        write_request = WriteRequest()
+        write_request.timeseries.extend(timeseries)
+        serialized_message = write_request.SerializeToString()
+        return snappy.compress(serialized_message)
 
     def get_headers(self) -> Dict:
-        raise NotImplementedError()
+        headers = {
+            "Content-Encoding": "snappy",
+            "Content-Type": "application/x-protobuf",
+            "X-Prometheus-Remote-Write-Version": "0.1.0",
+        }
+        if self.headers:
+            for header_name, header_value in self.headers.items():
+                headers[header_name] = header_value
+        return headers
 
     def send_message(
         self, message: bytes, headers: Dict
     ) -> MetricsExportResult:
-        raise NotImplementedError()
+        auth = None
+        if self.basic_auth:
+            basic_auth = self.basic_auth
+            if "password" in basic_auth:
+                auth = (basic_auth.username, basic_auth.password)
+            else:
+                with open(basic_auth.password_file) as file:
+                    auth = (basic_auth.username, file.readline())
+
+        cert = None
+        verify = True
+        if self.tls_config:
+            if "ca_file" in self.tls_config:
+                verify = self.tls_config["ca_file"]
+            elif "insecure_skip_verify" in self.tls_config:
+                verify = self.tls_config["insecure_skip_verify"]
+
+            if (
+                "cert_file" in self.tls_config
+                and "key_file" in self.tls_config
+            ):
+                cert = (
+                    self.tls_config["cert_file"],
+                    self.tls_config["key_file"],
+                )
+        response = requests.post(
+            self.endpoint,
+            data=message,
+            headers=headers,
+            auth=auth,
+            timeout=self.timeout,
+            proxies=self.proxies,
+            cert=cert,
+            verify=verify,
+        )
+        if response.status_code != 200:
+            logger.warning(
+                "POST request failed with status %s with reason: %s and content: %s",
+                str(response.status_code),
+                response.reason,
+                str(response.content),
+            )
+            return MetricsExportResult.FAILURE
+        return MetricsExportResult.SUCCESS

--- a/exporter/opentelemetry-exporter-prometheus-remote-write/tests/test_prometheus_remote_write_exporter.py
+++ b/exporter/opentelemetry-exporter-prometheus-remote-write/tests/test_prometheus_remote_write_exporter.py
@@ -313,25 +313,65 @@ class TestConversion(unittest.TestCase):
         self.assertEqual(timeseries, expected_timeseries)
 
 
+class ResponseStub:
+    def __init__(self, status_code):
+        self.status_code = status_code
+        self.reason = "dummy_reason"
+        self.content = "dummy_content"
+
+
 class TestExport(unittest.TestCase):
     # Initializes test data that is reused across tests
     def setUp(self):
-        pass
+        self._exporter = PrometheusRemoteWriteMetricsExporter(
+            endpoint="/prom/test_endpoint"
+        )
 
     # Ensures export is successful with valid export_records and config
-    def test_export(self):
-        pass
+    @mock.patch("requests.post", return_value=ResponseStub(200))
+    def test_export(self, mock_post):
+        test_metric = Counter("testname", "testdesc", "testunit", int, None)
+        labels = {"environment": "testing"}
+        record = ExportRecord(
+            test_metric, labels, SumAggregator(), Resource({}),
+        )
+        result = self._exporter.export([record])
+        self.assertIs(result, MetricsExportResult.SUCCESS)
+        self.assertEqual(mock_post.call_count, 1)
 
-    def test_valid_send_message(self):
-        pass
+    @mock.patch("requests.post", return_value=ResponseStub(200))
+    def test_valid_send_message(self, mock_post):
+        result = self._exporter.send_message(bytes(), {})
+        self.assertEqual(mock_post.call_count, 1)
+        self.assertEqual(result, MetricsExportResult.SUCCESS)
 
-    def test_invalid_send_message(self):
-        pass
+    @mock.patch("requests.post", return_value=ResponseStub(404))
+    def test_invalid_send_message(self, mock_post):
+        result = self._exporter.send_message(bytes(), {})
+        self.assertEqual(mock_post.call_count, 1)
+        self.assertEqual(result, MetricsExportResult.FAILURE)
 
     # Verifies that build_message calls snappy.compress and returns SerializedString
-    def test_build_message(self):
-        pass
+    @mock.patch("snappy.compress", return_value=bytes())
+    def test_build_message(self, mock_compress):
+        test_timeseries = [
+            TimeSeries(),
+            TimeSeries(),
+        ]
+        message = self._exporter.build_message(test_timeseries)
+        self.assertEqual(mock_compress.call_count, 1)
+        self.assertIsInstance(message, bytes)
 
     # Ensure correct headers are added when valid config is provided
     def test_get_headers(self):
-        pass
+        self._exporter.headers = {"Custom Header": "test_header"}
+
+        headers = self._exporter.get_headers()
+        self.assertEqual(headers.get("Content-Encoding", ""), "snappy")
+        self.assertEqual(
+            headers.get("Content-Type", ""), "application/x-protobuf"
+        )
+        self.assertEqual(
+            headers.get("X-Prometheus-Remote-Write-Version", ""), "0.1.0"
+        )
+        self.assertEqual(headers.get("Custom Header", ""), "test_header")


### PR DESCRIPTION
# Description
This is PR 4/7 of adding a Prometheus Remote Write Exporter in Python SDK and address Issue https://github.com/open-telemetry/opentelemetry-python/issues/1302

**[Part 1/7](https://github.com/open-o11y/opentelemetry-python-contrib/pull/10)**
* Adds class skeleton
* Adds all function signatures


**[Part 2/7](https://github.com/open-o11y/opentelemetry-python-contrib/pull/9)**
* Adds validation of exporter constructor commands
* Add unit tests for validation

**[Part 3/7](https://github.com/open-o11y/opentelemetry-python-contrib/pull/11)**
* Adds conversion methods from OTel metric types to Prometheus [TimeSeries](https://github.com/prometheus/prometheus/blob/master/prompb/types.proto#L47)
* Add unit tests for conversion


👉 **[Part 4/7](https://github.com/open-o11y/opentelemetry-python-contrib/pull/12)**
* Adds methods to export metrics to Remote Write endpoint
* Add unit tests for exporting

**Part 5/7**
* Add support for optional request parameters (timeout, proxy)
* Add support for tls config

**Part 6/7**
* Add integration tests using sample app and instance of Cortex

**Part 7/7**
* Add README, Design Doc and other necessary documentation.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
# How Has This Been Tested?

- [x] Added class `TestValidation` in `test_prometheus_remote_write_exporter.py`

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:
- [x] Followed the style guidelines of this project
- [ ] ~~Changelogs have been updated~~ (change logs will be updated when PR 7/7 is merged and the RW exporter is complete)
- [x] Unit tests have been added
- [ ] ~~Documentation has been updated~~
cc- @shovnik, @alolita 