### PR TITLE
Prometheus Remote Write Exporter (5/6)

### DIFF
--- a/tests/opentelemetry-docker-tests/tests/docker-compose.yml
+++ b/tests/opentelemetry-docker-tests/tests/docker-compose.yml
@@ -39,3 +39,15 @@ services:
         - "16686:16686"
         - "14268:14268"
         - "9411:9411"
+  cortex:
+    image: quay.io/cortexproject/cortex:v1.5.0
+    command:
+      - -config.file=./config/cortex-config.yml
+    volumes:
+      - ./prometheus-remote-write-cortex/cortex-config.yml:/config/cortex-config.yml:ro
+    ports:
+      - 9009:9009
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - 3000:3000

--- a/tests/opentelemetry-docker-tests/tests/prometheus-remote-write-cortex/cortex-config.yml
+++ b/tests/opentelemetry-docker-tests/tests/prometheus-remote-write-cortex/cortex-config.yml
@@ -1,0 +1,100 @@
+# This Cortex Config is copied from the Cortex Project documentation
+# Source: https://github.com/cortexproject/cortex/blob/master/docs/configuration/single-process-config.yaml
+
+# Configuration for running Cortex in single-process mode.
+# This configuration should not be used in production.
+# It is only for getting started and development.
+
+# Disable the requirement that every request to Cortex has a
+# X-Scope-OrgID header. `fake` will be substituted in instead.
+auth_enabled: false
+
+server:
+  http_listen_port: 9009
+
+  # Configure the server to allow messages up to 100MB.
+  grpc_server_max_recv_msg_size: 104857600
+  grpc_server_max_send_msg_size: 104857600
+  grpc_server_max_concurrent_streams: 1000
+
+distributor:
+  shard_by_all_labels: true
+  pool:
+    health_check_ingesters: true
+
+ingester_client:
+  grpc_client_config:
+    # Configure the client to allow messages up to 100MB.
+    max_recv_msg_size: 104857600
+    max_send_msg_size: 104857600
+    use_gzip_compression: true
+
+ingester:
+  # We want our ingesters to flush chunks at the same time to optimise
+  # deduplication opportunities.
+  spread_flushes: true
+  chunk_age_jitter: 0
+
+  walconfig:
+    wal_enabled: true
+    recover_from_wal: true
+    wal_dir: /tmp/cortex/wal
+
+  lifecycler:
+    # The address to advertise for this ingester.  Will be autodiscovered by
+    # looking up address on eth0 or en0; can be specified if this fails.
+    # address: 127.0.0.1
+
+    # We want to start immediately and flush on shutdown.
+    join_after: 0
+    min_ready_duration: 0s
+    final_sleep: 0s
+    num_tokens: 512
+    tokens_file_path: /tmp/cortex/wal/tokens
+
+    # Use an in memory ring store, so we don't need to launch a Consul.
+    ring:
+      kvstore:
+        store: inmemory
+      replication_factor: 1
+
+# Use local storage - BoltDB for the index, and the filesystem
+# for the chunks.
+schema:
+  configs:
+    - from: 2019-07-29
+      store: boltdb
+      object_store: filesystem
+      schema: v10
+      index:
+        prefix: index_
+        period: 1w
+
+storage:
+  boltdb:
+    directory: /tmp/cortex/index
+
+  filesystem:
+    directory: /tmp/cortex/chunks
+
+  delete_store:
+    store: boltdb
+
+purger:
+  object_store_type: filesystem
+
+frontend_worker:
+  # Configure the frontend worker in the querier to match worker count
+  # to max_concurrent on the queriers.
+  match_max_concurrent: true
+
+# Configure the ruler to scan the /tmp/cortex/rules directory for prometheus
+# rules: https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/#recording-rules
+ruler:
+  enable_api: true
+  enable_sharding: false
+  storage:
+    type: local
+    local:
+      directory: /tmp/cortex/rules
+

--- a/tests/opentelemetry-docker-tests/tests/prometheus-remote-write-cortex/prometheus_remote_write_cortex_test.py
+++ b/tests/opentelemetry-docker-tests/tests/prometheus-remote-write-cortex/prometheus_remote_write_cortex_test.py
@@ -1,0 +1,71 @@
+from opentelemetry import metrics
+from opentelemetry.exporter.prometheus_remote_write import (
+    PrometheusRemoteWriteMetricsExporter,
+)
+from opentelemetry.test.test_base import TestBase
+
+
+def observer_callback(observer):
+    array = [1.0, 15.0, 25.0, 26.0]
+    for (index, usage) in enumerate(array):
+        labels = {"test_label": str(index)}
+        observer.observe(usage, labels)
+
+
+class TestPrometheusRemoteWriteExporterCortex(TestBase):
+    def setUp(self):
+        super().setUp
+        self.exporter = PrometheusRemoteWriteMetricsExporter(
+            endpoint="http://localhost:9009/api/prom/push",
+            headers={"X-Scope-Org-ID": "5"},
+        )
+        self.labels = {"environment": "testing"}
+        self.meter = self.meter_provider.get_meter(__name__)
+        metrics.get_meter_provider().start_pipeline(
+            self.meter, self.exporter, 1,
+        )
+
+    def test_export_counter(self):
+        requests_counter = self.meter.create_counter(
+            name="counter",
+            description="test_export_counter",
+            unit="1",
+            value_type=int,
+        )
+        requests_counter.add(25, self.labels)
+
+    def test_export_valuerecorder(self):
+        requests_size = self.meter.create_valuerecorder(
+            name="valuerecorder",
+            description="test_export_valuerecorder",
+            unit="1",
+            value_type=int,
+        )
+        requests_size.record(25, self.labels)
+
+    def test_export_updowncounter(self):
+        requests_size = self.meter.create_updowncounter(
+            name="updowncounter",
+            description="test_export_updowncounter",
+            unit="1",
+            value_type=int,
+        )
+        requests_size.add(-25, self.labels)
+
+    def test_export_sumobserver(self):
+        self.meter.register_sumobserver(
+            callback=observer_callback,
+            name="sumobserver",
+            description="test_export_sumobserver",
+            unit="1",
+            value_type=float,
+        )
+
+    def test_export_updownsumobserver(self):
+        self.meter.register_updownsumobserver(
+            callback=observer_callback,
+            name="updownsumobserver",
+            description="test_export_updownsumobserver",
+            unit="1",
+            value_type=float,
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -198,7 +198,7 @@ commands_pre =
   test: pip install {toxinidir}/opentelemetry-python-core/opentelemetry-api {toxinidir}/opentelemetry-python-core/opentelemetry-sdk {toxinidir}/opentelemetry-python-core/tests/util
 
   test: pip install {toxinidir}/opentelemetry-python-core/opentelemetry-instrumentation
-  
+
   celery: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-celery[test]
 
   grpc: pip install {toxinidir}/instrumentation/opentelemetry-instrumentation-grpc[test]
@@ -308,7 +308,8 @@ deps =
   sqlalchemy ~= 1.3.16
   redis ~= 3.3.11
   celery ~= 4.0, != 4.4.4
-
+  protobuf>=3.13.0
+  requests==2.25.0
 changedir =
   tests/opentelemetry-docker-tests/tests
 
@@ -328,7 +329,10 @@ commands_pre =
               -e {toxinidir}/instrumentation/opentelemetry-instrumentation-aiopg \
               -e {toxinidir}/instrumentation/opentelemetry-instrumentation-redis \
               -e {toxinidir}/instrumentation/opentelemetry-instrumentation-system-metrics \
-              -e {toxinidir}/opentelemetry-python-core/exporter/opentelemetry-exporter-opencensus
+              -e {toxinidir}/opentelemetry-python-core/exporter/opentelemetry-exporter-opencensus \
+              -e {toxinidir}/exporter/opentelemetry-exporter-prometheus-remote-write
+  sudo apt-get install libsnappy-dev
+  pip install python-snappy
   docker-compose up -d
   python check_availability.py
 commands =


### PR DESCRIPTION
# Description
This is PR 5/6 of adding a Prometheus Remote Write Exporter in Python SDK and address Issue https://github.com/open-telemetry/opentelemetry-python/issues/1302

**[Part 1/6](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/180)**
* Adds class skeleton
* Adds all function signatures


**[Part 2/6](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/206)**
* Adds validation of exporter constructor commands
* Add unit tests for validation

**Part 3/6**
* Adds conversion methods from OTel metric types to Prometheus [TimeSeries](https://github.com/prometheus/prometheus/blob/master/prompb/types.proto#L47)
* Add unit tests for conversion


**Part 4/6**
* Adds methods to export metrics to Remote Write endpoint
* Add unit tests for exporting

👉 **Part 5/6**
* Add docker integration tests

**Part 6/6**
* Add README, Design Doc and other necessary documentation.
* Set up example app

## Type of change
- [x] New feature (non-breaking change which adds functionality)
# How Has This Been Tested?

- [ ] Added class `TestValidation` in `test_prometheus_remote_write_exporter.py`

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:
- [x] Followed the style guidelines of this project
- [ ] ~~Changelogs have been updated~~ (change logs will be updated when PR 7/7 is merged and the RW exporter is complete)
- [x] Unit tests have been added
- [ ] ~~Documentation has been updated~~
cc- @shovnik, @alolita 