### PR TITLE
Add schema_url attribute to Resource

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
     - 'release/*'
   pull_request:
 env:
-  CORE_REPO_SHA: 6e1219d5d6570f414b7188fab536bfcd4ab7700c
+  CORE_REPO_SHA: d3afaff745dac977c5e1c75162d4f7596a9ff2ad
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
     - 'release/*'
   pull_request:
 env:
-  CORE_REPO_SHA: d3afaff745dac977c5e1c75162d4f7596a9ff2ad
+  CORE_REPO_SHA: 3debbeed970094e630f12ce58039d94c11b8d288
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
     - 'release/*'
   pull_request:
 env:
-  CORE_REPO_SHA: 25b6746af2eac3a3ca72ab91d332cf8d317f9540
+  CORE_REPO_SHA: 6e1219d5d6570f414b7188fab536bfcd4ab7700c
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.2.0-0.21b0...HEAD)
 
+### Changed
+- `Resource` now has a `schema_url` field.
+  ([opentelemetry-python #1862](https://github.com/open-telemetry/opentelemetry-python/issues/1862))
 ### Added
 - `opentelemetry-instrumentation-botocore` now supports
   context propagation for lambda invoke via Payload embedded headers. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#504](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/504))
   ### Changed
 - Added optional `schema_url` field to `Resource` class
-  ([opentelemetry-python #1862](https://github.com/open-telemetry/opentelemetry-python/issues/1862))
+  ([#511](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/511))
 
 ### Added
 - `opentelemetry-instrumentation-botocore` now supports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-python/compare/v1.2.0-0.21b0...HEAD)
 
 ### Changed
-- `Resource` now has a `schema_url` field.
+- Added optional `schema_url` field to `Resource` class
   ([opentelemetry-python #1862](https://github.com/open-telemetry/opentelemetry-python/issues/1862))
 ### Added
 - `opentelemetry-instrumentation-botocore` now supports

--- a/exporter/opentelemetry-exporter-datadog/tests/test_datadog_exporter.py
+++ b/exporter/opentelemetry-exporter-datadog/tests/test_datadog_exporter.py
@@ -156,7 +156,8 @@ class TestDatadogSpanExporter(unittest.TestCase):
         )
 
         resource_without_service = Resource(
-            attributes={"conflicting_key": "conflicting_value"}, schema_url=""
+            attributes={"conflicting_key": "conflicting_value"}, 
+            schema_url="",
         )
 
         span_names = ("test1", "test2", "test3")

--- a/exporter/opentelemetry-exporter-datadog/tests/test_datadog_exporter.py
+++ b/exporter/opentelemetry-exporter-datadog/tests/test_datadog_exporter.py
@@ -76,7 +76,8 @@ class TestDatadogSpanExporter(unittest.TestCase):
         """Test the constructor passing all the options."""
         agent_url = "http://localhost:8126"
         exporter = datadog.DatadogSpanExporter(
-            agent_url=agent_url, service="explicit",
+            agent_url=agent_url,
+            service="explicit",
         )
 
         self.assertEqual(exporter.agent_url, agent_url)
@@ -151,11 +152,12 @@ class TestDatadogSpanExporter(unittest.TestCase):
             attributes={
                 "key_resource": "some_resource",
                 "service.name": "resource_service_name",
-            }
+            },
+            schema_url="",
         )
 
         resource_without_service = Resource(
-            attributes={"conflicting_key": "conflicting_value"}
+            attributes={"conflicting_key": "conflicting_value"}, schema_url=""
         )
 
         span_names = ("test1", "test2", "test3")
@@ -197,7 +199,7 @@ class TestDatadogSpanExporter(unittest.TestCase):
                 parent=parent_span_context,
                 kind=trace_api.SpanKind.CLIENT,
                 instrumentation_info=instrumentation_info,
-                resource=Resource({}),
+                resource=Resource({}, ""),
             ),
             trace._Span(
                 name=span_names[1],

--- a/exporter/opentelemetry-exporter-datadog/tests/test_datadog_exporter.py
+++ b/exporter/opentelemetry-exporter-datadog/tests/test_datadog_exporter.py
@@ -76,8 +76,7 @@ class TestDatadogSpanExporter(unittest.TestCase):
         """Test the constructor passing all the options."""
         agent_url = "http://localhost:8126"
         exporter = datadog.DatadogSpanExporter(
-            agent_url=agent_url,
-            service="explicit",
+            agent_url=agent_url, service="explicit",
         )
 
         self.assertEqual(exporter.agent_url, agent_url)

--- a/exporter/opentelemetry-exporter-datadog/tests/test_datadog_exporter.py
+++ b/exporter/opentelemetry-exporter-datadog/tests/test_datadog_exporter.py
@@ -156,8 +156,7 @@ class TestDatadogSpanExporter(unittest.TestCase):
         )
 
         resource_without_service = Resource(
-            attributes={"conflicting_key": "conflicting_value"}, 
-            schema_url="",
+            attributes={"conflicting_key": "conflicting_value"}, schema_url="",
         )
 
         span_names = ("test1", "test2", "test3")


### PR DESCRIPTION


A [change in the OTel specification](https://github.com/open-telemetry/opentelemetry-specification/pull/1692/files) requires a new `schema_url` field in the `Resource` class. This change modifies tests which used the old constructor signature. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All `tox` tests were ran on Python 3.9. One test was modified to account for the change in constructor signature.

# Does This PR Require a Contrib Repo Change?

- [The OTel specification](https://github.com/open-telemetry/opentelemetry-specification) has changed which prompted this PR to update the method interfaces of `opentelemetry-api/` or `opentelemetry-sdk/`

- [x] Yes. - Link to PR: https://github.com/open-o11y/opentelemetry-python/pull/23 NOTE: The GitHub workflow tests for this PR depend on the linked PR.
- [ ] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated - The documentation doesn't reference the method headers, so there's no update to the documentation.