### PR TITLE
Conditionally Creating Server Spans if No Span Found in Current Context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `opentelemetry-instrumentation-starlette`, `opentelemetry-instrumentation-urllib`, `opentelemetry-instrumentation-urllib3` Added `request_hook` and `response_hook` callbacks 
   ([#576](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/576))
 
+### Changed
+- Server instrumentations now look for parent spans in current context before extracting context from carriers. ([#544](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/544))
+
 ## [1.4.0-0.23b0](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.4.0-0.23b0) - 2021-07-21
 
 ### Removed

--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
@@ -129,15 +129,21 @@ def _wrapped_before_request(request_hook=None, tracer=None):
             return
         flask_request_environ = flask.request.environ
         span_name = get_default_span_name()
-        token = context.attach(
-            extract(flask_request_environ, getter=otel_wsgi.wsgi_getter)
-        )
+
+        token = ctx = span_kind = None
+
+        if trace.get_current_span() is trace.INVALID_SPAN:
+            ctx = extract(flask_request_environ, getter=otel_wsgi.wsgi_getter)
+            token = context.attach(ctx)
+            span_kind = trace.SpanKind.SERVER
 
         span = tracer.start_span(
             span_name,
-            kind=trace.SpanKind.SERVER,
+            ctx,
+            kind=span_kind,
             start_time=flask_request_environ.get(_ENVIRON_STARTTIME_KEY),
         )
+
         if request_hook:
             request_hook(span, flask_request_environ)
 
@@ -181,7 +187,8 @@ def _teardown_request(exc):
         activation.__exit__(
             type(exc), exc, getattr(exc, "__traceback__", None)
         )
-    context.detach(flask.request.environ.get(_ENVIRON_TOKEN))
+    if flask.request.environ.get(_ENVIRON_TOKEN, None) is not None:
+        context.detach(flask.request.environ.get(_ENVIRON_TOKEN))
 
 
 class _InstrumentedFlask(flask.Flask):


### PR DESCRIPTION
# Description

This PR fixes issue 445 in the opentelemetry-python-contrib repo. I implemented a decorator class called ServerSpanTracer that checks if if an active span is present in the current context by calling `opentelemetry.trace.get_current_span()`. If one is found, an internal span is created and the span found is used as the parent. If one is not found, a server span is created and the remote span context from the incoming request is used as a parent.

I used either this class or logic for all of the server instrumentations that create server spans: Falcon, Flask, Django, Pyramid, Tornado, WSGI, and ASGI. There are references to the issue that mention that FastAPI and Starlette also create server spans, but I could not find where this occurs in the opentelemetry-python-contrib repo. If someone could point out where they are created I can add the logic I used for the other instrumentations. 

## Type of change

Please delete options that are not relevant.

- [ ✅ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
     -This feature causes server spans to be only created conditionally, so at times existing functionality will not work as expected. 

# How Has This Been Tested?

In the `opentelemetry.util.tracer` module, I wrote my tests in `server_span_tracer_test.py`. I wrote a single test to ensure that when a span is not found in the current context, a server span is created instead of an internal span. I plan to also test that when a span is found in the current context, an internal span is created instead of a server span; however, I noticed that `trace.get_current_span()` kept on returning `INVALID_SPAN` no matter how I tried implementing this test case, so I have emitted it for now. The test can be run by calling `tox -e test-util-tracer`.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ✅ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ✅ ] Followed the style guidelines of this project
- [ ✅ ] Changelogs have been updated
- [ ✅ ] Unit tests have been added
- [ ✅ ] Documentation has been updated
